### PR TITLE
lodash.includes + spellbook react peerDependencies

### DIFF
--- a/packages/spellbook/package.json
+++ b/packages/spellbook/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@xstate-wizards/spells": "^0.5.28",
-    "@xstate-wizards/wizards-of-react": "^0.5.26",
+    "@xstate-wizards/wizards-of-react": "^0.5.28",
     "date-fns": "^2.4.1",
     "framer-motion": "^6.4.3",
     "lodash": "^4.17.20",

--- a/packages/spellbook/src/components/logic/JsonLogicBuilder.tsx
+++ b/packages/spellbook/src/components/logic/JsonLogicBuilder.tsx
@@ -294,6 +294,7 @@ const OPERATORS = {
     "lodash.concat",
     "lodash.get",
     "lodash.fill",
+    "lodash.includes",
     "lodash.isNil",
     "lodash.keys",
     "lodash.range",


### PR DESCRIPTION
needed an extra array method + a react rendering err makes me think spellbook carried in a separate react version