### PR TITLE
Markdown Attrs

### DIFF
--- a/examples/react-wizards/src/spells/exampleScreener.ts
+++ b/examples/react-wizards/src/spells/exampleScreener.ts
@@ -37,7 +37,7 @@ export const machineMapping = createSpell({
         { type: "p", text: "This is a screener to help you evaluate the XState Wizard™️ in front of you." },
         {
           type: "p",
-          text: `We'll keep a running score below, but before we get started, what's your name?`,
+          text: `We'll keep a running score of ~~Pain~~ [Wizard Points](https://google.com){"target":"_blank"}, but before we get started, what's your name?`,
         },
         {
           type: "resourceEditor",

--- a/packages/wizards-of-react/package.json
+++ b/packages/wizards-of-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xstate-wizards/wizards-of-react",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Mark Hansen",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/wizards-of-react/src/components/contentNodes/renderWizardML.tsx
+++ b/packages/wizards-of-react/src/components/contentNodes/renderWizardML.tsx
@@ -24,24 +24,38 @@ export function renderWizardML({ ctx, text, serializations, contentTree }: TWiza
   // the number of arguments in the handler.
   const PATTERNS = [
     {
-      // Bold - **bolded tex**
+      // Bold - **bolded text**
       pattern: "\\*\\*(.+?)\\*\\*",
       handler: (i, text) => <b key={i}>{text}</b>,
     },
     {
-      // Underlined - __underlined tex__
+      // Underlined - __underlined text__
       pattern: "\\__(.+?)\\__",
       handler: (i, text) => <u key={i}>{text}</u>,
     },
     {
-      // Hyperlink - [Link text](https://upsolve.org)
-      // If a relative link, it's internal so use react router dom <Link/>
-      pattern: "\\[(.+?)\\]\\((.+?)\\)",
-      handler: (i, text, url) => (
-        <A key={i} href={url}>
-          {text}
-        </A>
-      ),
+      // Strikethrough - ~~strike throughed text~~
+      pattern: "\\~~(.+?)\\~~",
+      handler: (i, text) => <del key={i}>{text}</del>,
+    },
+    {
+      // Hyperlink - [Link text](https://upsolve.org){"target":"_blank"}
+      // If a relative link, it's internal so use react router dom <Link/>. Attributes obj is optional.
+      pattern: "\\[(.+?)\\]\\((.+?)\\)(\\{.+?\\})?",
+      handler: (i, text, url, attrsString) => {
+        // Cast to JSON obj to keep life simple. Using other markdown syntax needs special parsing (ex: removing quotes). Only handles 1 layer of obj
+        let attrs: Record<string, any> = {};
+        try {
+          attrs = JSON.parse(attrsString);
+        } catch (e) {
+          // noop
+        }
+        return (
+          <A key={i} href={url} target={attrs.target}>
+            {text}
+          </A>
+        );
+      },
     },
     {
       // Javascript Selector Functions - <<<get("states.wizardScore")>>>


### PR DESCRIPTION
Extends link regex to check for a JSON object following link markdown. Along the way, threw in a strike through parser. 

| Strikethrough + Markdown Attrs |
| --- |
| <img width="477" alt="image" src="https://github.com/xstate-wizards/xstate-wizards/assets/4956240/5dd0cd5c-d590-400f-82b3-014e65b974ac"> |
