### PR TITLE
US phone numbers get formatted as typed

### DIFF
--- a/packages/wizards-of-react/package.json
+++ b/packages/wizards-of-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xstate-wizards/wizards-of-react",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "author": "Mark Hansen",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Small tweak to have stricter enforcement on US phone number length and also to give hints to how its formatted. This was bc sometimes people would double enter the +1 international phone code. Also passing the size prop to the input. Bumps `@xstate-wizards/wizards-of-react` to `0.8.6`. Shout out to @dl-eric for the tweaked component!

| Empty, with Suggestive Placeholder | Formatted as typed |
| --- | --- |
| <img width="629" alt="image" src="https://github.com/xstate-wizards/xstate-wizards/assets/4956240/dd613b36-7c67-4eb1-9802-0a1fc23f4517"> | <img width="625" alt="image" src="https://github.com/xstate-wizards/xstate-wizards/assets/4956240/2e149555-2da9-44f8-8347-a520bf4fee24"> |
