### PR TITLE
v3.1.0: spellbook layout

### DIFF
--- a/examples/react-spellbook/vite.config.ts
+++ b/examples/react-spellbook/vite.config.ts
@@ -5,6 +5,7 @@ import path from "path";
 // Dev mode: resolves workspace packages to their TypeScript source
 // (hot reload on package changes, no build step needed)
 const packages = path.resolve(__dirname, "../../packages");
+const rootNodeModules = path.resolve(__dirname, "../../node_modules");
 
 export default defineConfig({
   plugins: [react()],
@@ -15,9 +16,9 @@ export default defineConfig({
       "@xstate-wizards/wizards-of-react": path.join(packages, "wizards-of-react/src"),
       "@xstate-wizards/crystal-ball": path.join(packages, "crystal-ball/src"),
       "tel-fns": path.join(packages, "tel-fns/src"),
-      // Force all packages to share a single copy of these libraries
-      "xstate": path.join(packages, "spells/node_modules/xstate"),
-      "@xstate/react": path.join(packages, "wizards-of-react/node_modules/@xstate/react"),
+      // Force all packages to share a single copy of these libraries (hoisted to root)
+      "xstate": path.join(rootNodeModules, "xstate"),
+      "@xstate/react": path.join(rootNodeModules, "@xstate/react"),
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4143,7 +4143,7 @@
     },
     "packages/spellbook": {
       "name": "@xstate-wizards/spellbook",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dependencies": {
         "@xstate-wizards/spells": "^3.0.1",
         "@xstate-wizards/wizards-of-react": "^3.0.1",

--- a/packages/spellbook/package.json
+++ b/packages/spellbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xstate-wizards/spellbook",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "Mark Hansen",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/spellbook/src/components/contentNodes/ContentNodeAttrsEditor.tsx
+++ b/packages/spellbook/src/components/contentNodes/ContentNodeAttrsEditor.tsx
@@ -16,7 +16,7 @@ export const ContentNodeAttrsEditor: React.FC<TContentNodeAttrsEditorProps> = ({
   // console.log("ContentNodeAttrsEditor: ", { attrs, type, options });
   // RENDER
   return (
-    <div>
+    <div className="content-node__attrs-trigger">
       <button onClick={() => setIsDialogOpen(!isDialogOpen)} style={{ fontSize: "11px", letterSpacing: "-0.2px" }}>
         {"{...}"}
       </button>

--- a/packages/spellbook/src/components/contentNodes/ContentNodeEditor.tsx
+++ b/packages/spellbook/src/components/contentNodes/ContentNodeEditor.tsx
@@ -233,7 +233,7 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
                       </div>
                     </td>
                     <td>
-                      <button onClick={() => contentNodeUpdateHandler("options", omit(contentNode.options, [option]))}>
+                      <button className="stack-btn" onClick={() => contentNodeUpdateHandler("options", omit(contentNode.options, [option]))}>
                         ❌
                       </button>
                     </td>
@@ -242,6 +242,7 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
                 <tr>
                   <td className="stack-label">
                     <button
+                      className="stack-btn"
                       onClick={() => {
                         const newCondition = prompt("Condition value:");
                         if (newCondition)
@@ -251,7 +252,7 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
                           });
                       }}
                     >
-                      + Option
+                      +&nbsp;Option
                     </button>
                   </td>
                   <td></td>
@@ -319,6 +320,7 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
                               </td>
                               <td>
                                 <button
+                                  className="stack-btn"
                                   onClick={() =>
                                     contentNodeUpdateHandler("items", removeArrayItem(contentNode.items, optItem))
                                   }
@@ -863,6 +865,7 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
                               </td>
                               <td>
                                 <button
+                                  className="stack-btn"
                                   onClick={() =>
                                     contentNodeUpdateHandler("options", removeArrayItem(contentNode.options, optIndex))
                                   }

--- a/packages/spellbook/src/components/contentNodes/ContentNodeEditor.tsx
+++ b/packages/spellbook/src/components/contentNodes/ContentNodeEditor.tsx
@@ -104,7 +104,6 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
                 <select
                   value={contentNode.buttonType}
                   onChange={(e) => contentNodeUpdateHandler("buttonType", e.target.value)}
-                  style={{ display: "flex", maxWidth: "120px" }}
                 >
                   <option value="">Basic Button</option>
                   <option value="submit">Submit Button (Reqs Validation)</option>
@@ -130,7 +129,6 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
                         type: e.target.value,
                       })
                     }
-                    style={{ display: "flex", maxWidth: "120px" }}
                   >
                     <option value=""></option>
                     {Object.keys(state.on).map((on) => (
@@ -951,28 +949,24 @@ export const ContentNodeEditor: React.FC<TContentNodeEditorProps> = ({
         )}
       </div>
 
-      {/* ATTRS */}
-      <ContentNodeAttrsEditor
-        attrs={contentNode.attrs}
-        type={contentNode.type}
-        onUpdate={(attrs) => contentNodeUpdateHandler("attrs", attrs)}
-      />
-
-      {/* REORDERING */}
-      <div className="content-node__reorder-handle">
+      {/* ATTRS + REORDERING */}
+      <div className="content-node__actions">
+        <ContentNodeAttrsEditor
+          attrs={contentNode.attrs}
+          type={contentNode.type}
+          onUpdate={(attrs) => contentNodeUpdateHandler("attrs", attrs)}
+        />
         {canReorder && (
-          <div style={{ display: "flex", flexDirection: "column", maxWidth: "30px" }}>
+          <div className="content-node__reorder-arrows">
             <button
               disabled={contentNodeIndex === 0}
               onClick={() => onReorder(REORDER_DIRECTION.UP)}
-              style={{ maxHeight: "13px" }}
             >
               ⬆︎
             </button>
             <button
               disabled={contentNodeIndex === state.content.length - 1}
               onClick={() => onReorder(REORDER_DIRECTION.DOWN)}
-              style={{ maxHeight: "13px" }}
             >
               ⬇︎
             </button>

--- a/packages/spellbook/src/components/contentNodes/ContentNodeValidationList.tsx
+++ b/packages/spellbook/src/components/contentNodes/ContentNodeValidationList.tsx
@@ -40,7 +40,7 @@ export const ContentNodeValidationList = ({ onChange, validations, value }) => {
                 onChange((value ?? []).filter((validation) => validation !== v));
               }}
             >
-              ❌
+              ×
             </span>
           </small>
         ))}

--- a/packages/spellbook/src/components/logic/JsonLogicBuilder.tsx
+++ b/packages/spellbook/src/components/logic/JsonLogicBuilder.tsx
@@ -1,5 +1,5 @@
 import { castArray, cloneDeep } from "lodash";
-import React, { Fragment } from "react";
+import React from "react";
 import { $TSFixMe, TWizardSerializations } from "@xstate-wizards/spells";
 import { VariableSelector } from "./VariableSelector";
 
@@ -87,7 +87,7 @@ export const JsonLogicBuilder: React.FC<JsonLogicBuilderProps> = ({
       {/* ARGS */}
       <div className="logic__args">
         {existingArgs.map((arg, argIndex) => (
-          <Fragment key={`${argIndex}-${typeof arg}`}>
+          <div className="logic__arg" key={`${argIndex}-${typeof arg}`}>
             {/* --- var --- */}
             {typeof arg === "string" && existingOp === "var" ? (
               <VariableSelector
@@ -138,7 +138,7 @@ export const JsonLogicBuilder: React.FC<JsonLogicBuilderProps> = ({
                 states={states}
               />
             ) : null}
-          </Fragment>
+          </div>
         ))}
         {/* ADD ARGS -- only allow 1 arg if 'var' or 'return' */}
         <div className="logic__args__actions">

--- a/packages/spellbook/src/components/transitions/SpellStateEventTransitionsEditor.tsx
+++ b/packages/spellbook/src/components/transitions/SpellStateEventTransitionsEditor.tsx
@@ -170,22 +170,18 @@ export const SpellStateEventTransitionsEditor: React.FC<TSpellStateEventTransiti
             )}
           </div>
           <div className="transition__row-buttons">
-            <div style={{ display: "flex", flexDirection: "column", maxWidth: "30px" }}>
-              <button
-                disabled={transitionIndex === 0}
-                onClick={() => onUpdate(reorderArrayItem(transitionArr, transitionIndex, REORDER_DIRECTION.UP))}
-                style={{ maxHeight: "13px" }}
-              >
-                ⬆︎
-              </button>
-              <button
-                disabled={transitionIndex === transitionArr.length - 1}
-                onClick={() => onUpdate(reorderArrayItem(transitionArr, transitionIndex, REORDER_DIRECTION.DOWN))}
-                style={{ maxHeight: "13px" }}
-              >
-                ⬇︎
-              </button>
-            </div>
+            <button
+              disabled={transitionIndex === 0}
+              onClick={() => onUpdate(reorderArrayItem(transitionArr, transitionIndex, REORDER_DIRECTION.UP))}
+            >
+              ⬆︎
+            </button>
+            <button
+              disabled={transitionIndex === transitionArr.length - 1}
+              onClick={() => onUpdate(reorderArrayItem(transitionArr, transitionIndex, REORDER_DIRECTION.DOWN))}
+            >
+              ⬇︎
+            </button>
             <button onClick={() => onUpdate(removeArrayItem(transitions, transitionIndex))}>❌</button>
           </div>
         </div>

--- a/packages/spellbook/src/styles.css
+++ b/packages/spellbook/src/styles.css
@@ -836,10 +836,13 @@
 .xw-sb__content-node-editor {
   display: flex;
   width: 100%;
-  padding: 4px 0;
-  border-bottom: 1px solid #eee;
+  padding: 4px 1em;
+  border-bottom: 1px solid #ddd;
   position: relative;
   transition: background 0.15s ease;
+}
+.xw-sb__content-node-editor:nth-child(even) {
+  background: #fcfcfc;
 }
 .xw-sb__content-node-editor:last-of-type {
   border-bottom: none;
@@ -1104,18 +1107,61 @@
 
 .xw-sb__validation-list .active-validations {
   display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  margin-left: 4px;
 }
 
 .xw-sb__validation-list .active-validations small {
-  margin-left: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: #e8e8e8;
+  border-radius: 3px;
+  padding: 0px 4px;
+  font-size: 11px;
+  max-height: 18px;
+  white-space: nowrap;
+}
+
+.xw-sb__validation-list .active-validations small span {
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  opacity: 0.6;
+}
+
+.xw-sb__validation-list .active-validations small span:hover {
+  opacity: 1;
 }
 
 /* --- JSON Logic Builder -------------------------------------------------- */
 .xw-sb__json-logic {
   display: flex;
-  padding-left: 2px;
-  border-left: 2px solid #ccc;
+  padding: 2px 0 2px 2px;
+  border-left: 2px solid #6c9bd1;
   margin-left: 2px;
+  background: rgba(108, 155, 209, 0.06);
+  border-radius: 0 3px 3px 0;
+}
+
+/* Alternating nesting colors */
+.xw-sb__json-logic .xw-sb__json-logic {
+  border-left-color: #d1a06c;
+  background: rgba(209, 160, 108, 0.06);
+}
+.xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic {
+  border-left-color: #8c6cd1;
+  background: rgba(140, 108, 209, 0.06);
+}
+.xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic {
+  border-left-color: #6cb8a0;
+  background: rgba(108, 184, 160, 0.06);
+}
+
+.xw-sb__json-logic .logic__operation {
+  flex-shrink: 0;
 }
 
 .xw-sb__json-logic input,
@@ -1127,6 +1173,24 @@
 .xw-sb__json-logic .logic__args {
   display: flex;
   flex-direction: column;
+  gap: 2px;
+}
+
+.xw-sb__json-logic .logic__arg {
+  border-left: 2px solid #6c9bd1;
+  padding-left: 2px;
+  margin-left: 2px;
+}
+
+/* Match arg border colors to parent nesting level */
+.xw-sb__json-logic .xw-sb__json-logic .logic__arg {
+  border-left-color: #d1a06c;
+}
+.xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .logic__arg {
+  border-left-color: #8c6cd1;
+}
+.xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .logic__arg {
+  border-left-color: #6cb8a0;
 }
 
 .xw-sb__json-logic .logic__args__actions {
@@ -1338,7 +1402,7 @@
 }
 
 .xw-sb__state-content .xw-sb__spell-state__content-nodes {
-  padding: 0.5em 1em 0;
+  padding: 0;
 }
 
 .xw-sb__state-content .xw-sb__spell-state__content-nodes--none {

--- a/packages/spellbook/src/styles.css
+++ b/packages/spellbook/src/styles.css
@@ -432,7 +432,7 @@
   margin: 0 4px;
 }
 
-.xw-sb__states .content-node--reorder-handle {
+.xw-sb__states .content-node__actions {
   display: flex;
   flex-direction: row;
 }
@@ -451,7 +451,7 @@
   width: 100%;
   background: white;
   border-radius: 4px;
-  overflow: hidden;
+  overflow: visible;
   margin: 1em 0 1.5em;
   box-shadow: 0 4px 16px 0 rgba(228, 228, 230, 1), 0 4px 16px 0 rgba(228, 228, 230, 1),
     0 4px 16px 0 rgba(228, 228, 230, 1), 0 2px 4px 0 rgba(228, 228, 230, 1);
@@ -477,7 +477,7 @@
 }
 
 .xw-sb__state .xw-sb__spell-state__body {
-  overflow-y: scroll;
+  overflow: visible;
 }
 
 .xw-sb__state .xw-sb__spell-state__body__events {
@@ -836,6 +836,16 @@
 .xw-sb__content-node-editor {
   display: flex;
   width: 100%;
+  padding: 4px 0;
+  border-bottom: 1px solid #eee;
+  position: relative;
+  transition: background 0.15s ease;
+}
+.xw-sb__content-node-editor:last-of-type {
+  border-bottom: none;
+}
+.xw-sb__content-node-editor:hover {
+  background: rgba(0, 0, 0, 0.02);
 }
 
 .xw-sb__content-node-editor .content-node__type {
@@ -881,8 +891,8 @@
 }
 
 .xw-sb__content-node-editor .content-node__config__stack td.stack-label {
-  max-width: 220px;
-  width: 15%;
+  max-width: 100px;
+  width: 100px;
   font-size: 12px;
 }
 
@@ -900,12 +910,37 @@
   margin: 0 4px;
 }
 
-.xw-sb__content-node-editor .content-node__reorder-handle {
+.xw-sb__content-node-editor .content-node__actions {
+  display: none;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 100%;
+  z-index: 1;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 1px 2px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  white-space: nowrap;
+}
+.xw-sb__content-node-editor:hover > .content-node__actions {
   display: flex;
 }
 
-.xw-sb__content-node-editor .content-node__reorder-handle button {
-  font-size: 7px;
+.xw-sb__content-node-editor .content-node__actions .content-node__attrs-trigger {
+  display: flex;
+  height: 100%;
+}
+
+.xw-sb__content-node-editor .content-node__actions button {
+  font-size: 10px;
+  height: 100%;
+}
+
+.xw-sb__content-node-editor .content-node__actions .content-node__reorder-arrows {
+  display: flex;
+  flex-direction: row;
 }
 
 .xw-sb__content-node-editor .content-node__config__select-options {
@@ -940,7 +975,7 @@
 }
 
 .xw-sb__content-node-adder select {
-  max-width: 80px;
+  max-width: 110px;
   width: 100%;
 }
 
@@ -1086,7 +1121,7 @@
 .xw-sb__json-logic input,
 .xw-sb__json-logic select {
   flex-grow: 1;
-  max-width: 100px;
+  max-width: 160px;
 }
 
 .xw-sb__json-logic .logic__args {
@@ -1278,7 +1313,6 @@
 .xw-sb__input-assign .input-assign__editor>input,
 .xw-sb__input-assign .input-assign__editor>select {
   flex-grow: 1;
-  max-width: 120px;
   margin: 0 4px;
 }
 

--- a/packages/spellbook/src/styles.css
+++ b/packages/spellbook/src/styles.css
@@ -13,6 +13,7 @@
   bottom: 0;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
+
 .xw-sb__spellbook button,
 .xw-sb__spellbook input,
 .xw-sb__spellbook select,
@@ -288,6 +289,7 @@
   flex-wrap: wrap;
   font-size: 12px;
 }
+
 .xw-sb__locale-tag {
   display: inline-flex;
   align-items: center;
@@ -297,6 +299,7 @@
   padding: 1px 6px;
   font-size: 12px;
 }
+
 .xw-sb__locale-tag button {
   background: none;
   border: none;
@@ -305,17 +308,21 @@
   padding: 0 2px;
   color: #888;
 }
+
 .xw-sb__locale-tag button:hover {
   color: #c00;
 }
+
 .xw-sb__locale-selector {
   display: inline-flex;
   align-items: center;
   gap: 4px;
 }
+
 .xw-sb__locale-selector small {
   white-space: nowrap;
 }
+
 .xw-sb__config-editor .xw-sb__locale-editor {
   flex-shrink: 0;
 }
@@ -841,12 +848,15 @@
   position: relative;
   transition: background 0.15s ease;
 }
+
 .xw-sb__content-node-editor:nth-child(even) {
   background: #fcfcfc;
 }
+
 .xw-sb__content-node-editor:last-of-type {
   border-bottom: none;
 }
+
 .xw-sb__content-node-editor:hover {
   background: rgba(0, 0, 0, 0.02);
 }
@@ -893,10 +903,17 @@
   width: 100%;
 }
 
+.xw-sb__content-node-editor .stack-btn,
+.xw-sb__content-node-editor .add-option-button {
+  font-size: 7px;
+  white-space: nowrap;
+}
+
 .xw-sb__content-node-editor .content-node__config__stack td.stack-label {
   max-width: 100px;
   width: 100px;
   font-size: 11px;
+  padding-left: 2px;
 }
 
 .xw-sb__content-node-editor .content-node__config__stack td.stack-label .stack-label__actions small {
@@ -927,7 +944,8 @@
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   white-space: nowrap;
 }
-.xw-sb__content-node-editor:hover > .content-node__actions {
+
+.xw-sb__content-node-editor:hover>.content-node__actions {
   display: flex;
 }
 
@@ -1151,10 +1169,12 @@
   border-left-color: #d1a06c;
   background: rgba(209, 160, 108, 0.06);
 }
+
 .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic {
   border-left-color: #8c6cd1;
   background: rgba(140, 108, 209, 0.06);
 }
+
 .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic {
   border-left-color: #6cb8a0;
   background: rgba(108, 184, 160, 0.06);
@@ -1186,9 +1206,11 @@
 .xw-sb__json-logic .xw-sb__json-logic .logic__arg {
   border-left-color: #d1a06c;
 }
+
 .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .logic__arg {
   border-left-color: #8c6cd1;
 }
+
 .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .xw-sb__json-logic .logic__arg {
   border-left-color: #6cb8a0;
 }
@@ -1670,9 +1692,11 @@
   padding: 4px 0;
   border-bottom: 1px solid #ccc;
 }
+
 .xw-sb__event-transitions .transition:last-of-type {
   border-bottom: none;
 }
+
 .xw-sb__event-transitions .transition:nth-child(even) {
   background: rgba(0, 0, 0, 0.02);
 }
@@ -1738,7 +1762,8 @@
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   white-space: nowrap;
 }
-.xw-sb__event-transitions .transition:hover > .transition__row-buttons {
+
+.xw-sb__event-transitions .transition:hover>.transition__row-buttons {
   display: flex;
 }
 

--- a/packages/spellbook/src/styles.css
+++ b/packages/spellbook/src/styles.css
@@ -896,7 +896,7 @@
 .xw-sb__content-node-editor .content-node__config__stack td.stack-label {
   max-width: 100px;
   width: 100px;
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .xw-sb__content-node-editor .content-node__config__stack td.stack-label .stack-label__actions small {
@@ -1480,7 +1480,7 @@
 
 /* --- State Invoke Editor ------------------------------------------------- */
 .xw-sb__state-invoke {
-  padding: 0em 1em 0.5em;
+  padding: 0.5em 1em 0.5em;
   background: #fff;
   overflow-x: scroll;
 }
@@ -1620,7 +1620,7 @@
 .xw-sb__events-editor {
   padding: 0.5em 1em;
   background: #f0f0f0;
-  overflow-x: scroll;
+  overflow: visible;
 }
 
 .xw-sb__events-editor .on-event {
@@ -1666,7 +1666,15 @@
   display: flex;
   justify-content: space-between;
   flex-direction: row;
-  margin-bottom: 0.2em;
+  position: relative;
+  padding: 4px 0;
+  border-bottom: 1px solid #ccc;
+}
+.xw-sb__event-transitions .transition:last-of-type {
+  border-bottom: none;
+}
+.xw-sb__event-transitions .transition:nth-child(even) {
+  background: rgba(0, 0, 0, 0.02);
 }
 
 .xw-sb__event-transitions .transition__details {
@@ -1697,7 +1705,12 @@
   bottom: -2px;
 }
 
+.xw-sb__event-transitions .transition__details__logic-holder {
+  min-width: 80px;
+}
+
 .xw-sb__event-transitions .transition__details__actions {
+  min-width: 80px;
   margin: 0 4px;
 }
 
@@ -1712,13 +1725,26 @@
 }
 
 .xw-sb__event-transitions .transition__row-buttons {
+  display: none;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 100%;
+  z-index: 1;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 1px 2px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  white-space: nowrap;
+}
+.xw-sb__event-transitions .transition:hover > .transition__row-buttons {
   display: flex;
-  align-items: flex-end;
 }
 
 .xw-sb__event-transitions .transition__row-buttons button {
-  max-height: 26px;
-  font-size: 7px;
+  font-size: 10px;
+  height: 100%;
 }
 
 .xw-sb__event-transitions .add-transition {


### PR DESCRIPTION
Now the last frontier of this era is out of the box developer experience on the no-code editor, and maybe a bit nicer defaults for the wizards.

- [x] editor: moved content node re-ordering/deleting buttons to be positioned relatively on hover, not take up space by default
- [x] editor: more filled out inputs/dropdowns etc. 
- [x] editor: more distinct content nodes to help see how inputs group
- [x] editor: smaller stack buttons